### PR TITLE
Handle kill signal

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,11 +12,11 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#include <signal.h>
 
 #ifdef __GNUC__
 #include <stdio.h>
 #include <execinfo.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
 #endif
@@ -44,6 +44,11 @@ void handler(int sig)
     exit(1);
 }
 #endif
+
+void stop_handler(int /*sig*/)
+{
+    exit(0);
+}
 
 bool should_print_version(int argc, char* argv[])
 {
@@ -100,8 +105,11 @@ int main(int argc, char* argv[])
 #ifdef __GNUC__
     std::clog << "registering handler for SIGSEGV" << std::endl;
     signal(SIGSEGV, handler);
-#endif
 
+    // Registering SIGINT and SIGKILL handlers
+    signal(SIGKILL, stop_handler);
+#endif
+    signal(SIGINT, stop_handler);
 
 
     // Instantiating the xeus xinterpreter


### PR DESCRIPTION
Since jupyter_client = 7.x, the kernel gets killed agressively, we need to handle it