### PR TITLE
using lang. agnostic name in xeus wasm kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,9 +366,9 @@ endif()
 if(XEUS_LUA_EMSCRIPTEN_WASM_BUILD)
     message(STATUS ${LUA_LIBRARIES})
 
-    add_executable(xeus_lua src/main_emscripten_kernel.cpp )
-    target_link_libraries(xeus_lua  xeus-lua-static)# ${LUA_LIBRARY} )
-    target_compile_features(xeus_lua PRIVATE cxx_std_17)
+    add_executable(xeus_kernel src/main_emscripten_kernel.cpp )
+    target_link_libraries(xeus_kernel  xeus-lua-static)# ${LUA_LIBRARY} )
+    target_compile_features(xeus_kernel PRIVATE cxx_std_17)
 
 endif()
 


### PR DESCRIPTION
this will then create `xeus_kernel.wasm` / `xeus_kernel.js` instead of `xeus_lua.XXX`.
This will help to create "common" code for jupyterlite which is used by multiple kernels